### PR TITLE
Fix get_users view if there is no get data passed.

### DIFF
--- a/django_project/user_map/views.py
+++ b/django_project/user_map/views.py
@@ -91,18 +91,22 @@ def get_users(request):
     """
 
     if request.method == 'GET':
+
         # Get data:
-        project = str(request.GET['project'])
+        project = str(request.GET.get('project', ''))
 
         if project.lower() == 'inasafe':
             users = User.objects.filter(
                 is_confirmed=True,
                 is_active=True,
                 osm_roles=None)
-        else:
+        elif project.lower() == 'openstreetmap':
             inasafe_users = User.objects.filter(osm_roles=None).values('id')
             users = User.objects.filter(
-                is_confirmed=True).exclude(id__in=inasafe_users)
+                is_confirmed=True,
+                is_active=True).exclude(id__in=inasafe_users)
+        else:
+            users = []
 
         context = {
             'users': users,


### PR DESCRIPTION
In some case e.g googlebot tries to access this view without passing any data. Just return empty user in that case.